### PR TITLE
Clarify the included services, by subscription

### DIFF
--- a/Viva/insights/personal/Overview/plans-environments.md
+++ b/Viva/insights/personal/Overview/plans-environments.md
@@ -25,23 +25,23 @@ Microsoft Viva Insights provides personal insights in the [Viva Insights app in 
 
 The following Personal insights service plans are generally available with a subscription to the Microsoft 365 plans listed for each. Also see [Supported](#supported-microsoft-365-environments) and [Not supported](#not-supported-microsoft-365-environments) Microsoft 365 environments to confirm your type of environment is supported.
 
-* [**Viva Insights service plan**](https://www.microsoft.com/microsoft-viva/buy-insights) are available with:
+* [**Viva Insights service plan**](https://www.microsoft.com/microsoft-viva/buy-insights) is available (to buy) with:
 
   * Microsoft 365 E3, A3, E5, A5, Business Basic, Business Standard, or Business Premium
   * Office 365 E1, E3, A3, E5, A5, G3, G5, or GCC
   * Exchange Online Plan 1 or 2
 
-* **MyAnalytics (Full)** and **Insights by MyAnalytics** service plans are available with:
+* **MyAnalytics (Full)** and **Insights by MyAnalytics** service plans are included with:
 
   * Microsoft 365 E5 (with or without Audio Conferencing) or G5
   * Office 365 Enterprise, G5, or Nonprofit E5
 
-* **MyAnalytics (Full)** service plan is available with:
+* **MyAnalytics (Full)** service plan is included with:
 
   * Microsoft 365 A5 for faculty and students
   * Office 365 A5 for faculty and students
 
-* **Insights by MyAnalytics** service plan is available with:
+* **Insights by MyAnalytics** service plan is included with:
 
   * Microsoft 365 E3, Business, or A3 for faculty and students
   * Office 365 E1, E3, A3 for faculty and students, E3 Developer, G3, Business Premium, or Business Essentials


### PR DESCRIPTION
We had a ticket (an E3 user couldn't opt-in  for Delay delivery) open for at least a week with several escalations until we got: 

> Please note that MyAnalytics (Full) service plan is contained with the Microsoft 365 E5 license and only users with Microsoft 365 or Office 365 E1/A1/G1/E3/A3/G3/E5/A5/G5, Microsoft 365 Business Basic, Business Standard, Business Premium, or Exchange Online Plan 1 or Plan 2 are eligible to purchase and assign the Microsoft Viva Insights plan.

However, I can't see a difference between what is "eligible to purchase" and "contained "on this docs page. I'm not alone (#294, and I suspect #226).