### PR TITLE
Add instructions for pinning the Viva Connections app

### DIFF
--- a/Viva/connections/add-viva-connections-app.md
+++ b/Viva/connections/add-viva-connections-app.md
@@ -64,10 +64,20 @@ After you have [prepared your intranet for Viva Connections](guide-to-setting-up
 
 ## Then, customize the app settings
 
-1. Optionally (but highly recommended) use Teams app setup policy to pre-install and pre-pin the app for users on the Teams app bar on desktop and mobile. [Learn more about Teams app set up policies](/MicrosoftTeams/teams-app-setup-policies).
+Most organizations want to pin the Viva Connections app to the top of the Teams App Bar for all users. This can be accomplished by changing the pinned apps in the Teams Admin Center under [Setup policies](/MicrosoftTeams/teams-app-setup-policies).
 
-2. Optionally (but highly recommended) set app permissions policies to determine which users have access to the app. [Learn more about Teams permission policies](/microsoftteams/teams-app-permission-policies).
+1. Navigate to the **Teams Admin Center** / **Teams apps** / **Setup policies**
+2. Select **Global (Org-wide default)** - This is the default policy for all users.
+3. Scroll down to **Pinned apps**
+4. Click on **+ Add apps**
+5. In the second box, search for the Viva Connections app you enabled with the name you gave it, e.g., Intranet
+6. Click **Add** next to the app name and then **Add** at the bottom of the panel.
+7. Use the two horizontal lines next to the app to drag it to the top of the app list
+8. Click **Save** at the bottom of the page
 
+If your needs are different, [learn more about Teams app set up policies](/MicrosoftTeams/teams-app-setup-policies).
+
+Optionally (but highly recommended) set app permissions policies to determine which users have access to the app. [Learn more about Teams permission policies](/microsoftteams/teams-app-permission-policies).
 
 ## Finally, make the app available to end users
 
@@ -86,28 +96,3 @@ After you have [prepared your intranet for Viva Connections](guide-to-setting-up
 <br>
 
 [Set up and launch Viva Connections](guide-to-setting-up-viva-connections.md)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/Viva/connections/add-viva-connections-app.md
+++ b/Viva/connections/add-viva-connections-app.md
@@ -75,7 +75,7 @@ Most organizations want to pin the Viva Connections app to the top of the Teams 
 7. Use the two horizontal lines next to the app to drag it to the top of the app list
 8. Click **Save** at the bottom of the page
 
-If your needs are different, [learn more about Teams app set up policies](/MicrosoftTeams/teams-app-setup-policies).
+If your needs are different, [learn more about Teams app setup policies](/MicrosoftTeams/teams-app-setup-policies).
 
 Optionally (but highly recommended) set app permissions policies to determine which users have access to the app. [Learn more about Teams permission policies](/microsoftteams/teams-app-permission-policies).
 

--- a/Viva/connections/add-viva-connections-app.md
+++ b/Viva/connections/add-viva-connections-app.md
@@ -66,13 +66,13 @@ After you have [prepared your intranet for Viva Connections](guide-to-setting-up
 
 Most organizations want to pin the Viva Connections app to the top of the Teams app bar for all users. This can be accomplished by changing the pinned apps in the Microsoft Teams admin center under [Setup policies](/MicrosoftTeams/teams-app-setup-policies).
 
-1. Navigate to the **Teams Admin Center** / **Teams apps** / **Setup policies**
-2. Select **Global (Org-wide default)** - This is the default policy for all users.
-3. Scroll down to **Pinned apps**
-4. Click on **+ Add apps**
-5. In the second box, search for the Viva Connections app you enabled with the name you gave it, e.g., Intranet
-6. Click **Add** next to the app name and then **Add** at the bottom of the panel.
-7. Use the two horizontal lines next to the app to drag it to the top of the app list
+1. Navigate to the **Teams admin center** > **Teams apps** > **Setup policies**.
+2. Select **Global (Org-wide default)** (this is the default policy for all users).
+3. Scroll down to **Pinned apps**.
+4. Select **+ Add apps**.
+5. In the second box, search for the Viva Connections app you enabled with the name you gave it, for example, Intranet.
+6. Select **Add** next to the app name and then **Add** at the bottom of the panel.
+7. Use the two horizontal lines next to the app to drag it to the top of the app list.
 8. Click **Save** at the bottom of the page
 
 If your needs are different, [learn more about Teams app setup policies](/MicrosoftTeams/teams-app-setup-policies).

--- a/Viva/connections/add-viva-connections-app.md
+++ b/Viva/connections/add-viva-connections-app.md
@@ -73,7 +73,7 @@ Most organizations want to pin the Viva Connections app to the top of the Teams 
 5. In the second box, search for the Viva Connections app you enabled with the name you gave it, for example, Intranet.
 6. Select **Add** next to the app name and then **Add** at the bottom of the panel.
 7. Use the two horizontal lines next to the app to drag it to the top of the app list.
-8. Click **Save** at the bottom of the page
+8. Select **Save** at the bottom of the page.
 
 If your needs are different, [learn more about Teams app setup policies](/MicrosoftTeams/teams-app-setup-policies).
 

--- a/Viva/connections/add-viva-connections-app.md
+++ b/Viva/connections/add-viva-connections-app.md
@@ -64,7 +64,7 @@ After you have [prepared your intranet for Viva Connections](guide-to-setting-up
 
 ## Then, customize the app settings
 
-Most organizations want to pin the Viva Connections app to the top of the Teams App Bar for all users. This can be accomplished by changing the pinned apps in the Teams Admin Center under [Setup policies](/MicrosoftTeams/teams-app-setup-policies).
+Most organizations want to pin the Viva Connections app to the top of the Teams app bar for all users. This can be accomplished by changing the pinned apps in the Microsoft Teams admin center under [Setup policies](/MicrosoftTeams/teams-app-setup-policies).
 
 1. Navigate to the **Teams Admin Center** / **Teams apps** / **Setup policies**
 2. Select **Global (Org-wide default)** - This is the default policy for all users.


### PR DESCRIPTION
I discussed this with @pamgreen-msft on a call today. I'd guess the majority of people setting up Viva Connections want to pin the app to the top of the Teams App Bar. That's how they have seen it shown in all of the demos and screenshots from Microsoft. When I was setting up Viva Connections for a client today, I sort of knew I needed to pin the app, but I slid right past the part about it in this article.

So, my suggested edit is to include the "fastest path to joy" to accomplish this, with a link to info about Setup Policies rather than just linking to that article, which covers many other aspects of the topic.