### PR TITLE
Update sharepoint-permissions.md

### DIFF
--- a/Viva/learning/sharepoint-permissions.md
+++ b/Viva/learning/sharepoint-permissions.md
@@ -53,7 +53,7 @@ Document library folder URLs can be collected from any SharePoint site in the or
 >[!NOTE]
 > It will take approximately 24 hours for these changes to show up in the Viva Learning app.
 
-To remove unintentionally surfaced content, follow these steps:
+## Remove unintentionally surfaced content
 
 1. To restrict access to the document library, select the **Show actions** option, and then select **Manage access**.
 


### PR DESCRIPTION
I think the section I changed should be notably separate/highlighted & well identified as to prevent any mixup.

If we just leave the text "to remove (...) content, please follow:" in the exact same style/font with no separators i feel it will induce users in error (and already induced several of my colleagues who were mixed up "why are they now removing access" ... until they noticed it's actually a different section)

I would ask your insight from the Writers team though on the best form to phrase it :) ... I was undecided between leaving the same term, or just switching to "Remove Content Access"  ... but felt somewhat "empty" ... I will leave that to your decision! :)

Thank you so much for the support & help!