### PR TITLE
Avoid usage of "Duration" as internal name of content duration to avo…

### DIFF
--- a/Viva/learning/configure-sharepoint-content-source.md
+++ b/Viva/learning/configure-sharepoint-content-source.md
@@ -174,7 +174,7 @@ Next, add the duration of the content.
 
 1. Follow the initial steps to create a column.
 2. Choose **Number**.
-3. Name the column Duration.
+3. Name the column ContentDuration.
 4. Provide the duration of the content in seconds.
 
 Next, add tags.


### PR DESCRIPTION
…id conflict with global site column

SharePoint already has a site column with internal name "Duration" - this is field with GUID {4D54445D-1C84-4a6d-B8DB-A51DED4E1ACC} which is used in calendar event schema and is a hidden field of type integer. 

I strongly advise and recommend development team adopts a new less generic name such as "ContentDuration" so that a Viva Learning content type may be created at the Content Type Hub level and pushed down through syndication. If we keep "Duration" as the internal site column name, we are welcoming unnecessary trouble in future iterations should Microsoft decide to make the field global. Please reconsider the internal name of this field which will require documentation and code updates in the Viva Learning service.