### PR TITLE
Update set-up-admin-center.md

### DIFF
--- a/Viva/connections/set-up-admin-center.md
+++ b/Viva/connections/set-up-admin-center.md
@@ -76,7 +76,7 @@ Create an all-encompassing Connections experience for the entire organization, o
 > [!NOTE]
 >
 > - Organizations are limited to creating a maximum of ten Viva Connections experiences overall per tenant.
-> - A Microsoft Viva Suite license is required to create three or more Viva Connections experiences. Check the [current license for your organization in billing under licenses](https://www.microsoft.com/microsoft-viva/pricing).
+> - A Microsoft Viva Suite license is required to create more than three Viva Connections experiences. Check the [current license for your organization in billing under licenses](https://www.microsoft.com/microsoft-viva/pricing).
 > - You must have Global admin permissions, SharePoint admin permissions, or higher to access the MAC.
 > - If this is the first time you're setting up Viva Connections, it's recommended you pin the app in Teams.
 


### PR DESCRIPTION
The original language contradicts the language at the top of the page. A Viva Suite license is required for more than three, not three or more. I believe that you can create up to three instances with a standard license.