### PR TITLE
Add DraftMode parameter for setting Connections default experience

### DIFF
--- a/Viva/connections/edit-viva-home.md
+++ b/Viva/connections/edit-viva-home.md
@@ -265,8 +265,8 @@ If your organization already has a SharePoint home site and you want to keep it 
 
    - The VivaConnectionsDefault parameter should be set to **$false** to use the new Connections desktop experience as the default landing experience.
    - The VivaConnectionsDefault parameter should be set to **$true** to use a SharePoint home site as the default landing experience.
-   - The DraftMode parameter is set to **$true** by default, which will disable the global navigation and home site. The Connections desktop experience can be enabled in the Microsoft 365 Admin Center.
-   - Set the DraftMode parameter to **$false** to immediately enable the Connections desktop experience without going through the Admin Center.
+   - The DraftMode parameter is set to **$true** by default, which will disable the global navigation and home site. The Connections desktop experience can be enabled in the Microsoft 365 admin center.
+   - Set the DraftMode parameter to **$false** to immediately enable the Connections desktop experience without going through the admin center.
 
    **Example:**
 

--- a/Viva/connections/edit-viva-home.md
+++ b/Viva/connections/edit-viva-home.md
@@ -261,10 +261,12 @@ If your organization already has a SharePoint home site and you want to keep it 
 
 2. Connect to SharePoint as a [Global Administrator](/microsoft-365/admin/add-users/about-admin-roles) in Microsoft 365. To learn how, see [Getting started with SharePoint Online Management Shell](/powershell/sharepoint/sharepoint-online/connect-sharepoint-online).
 
-3. Run `Set-SPOHomeSite -HomeSiteUrl <homesiteURL> -VivaConnectionsDefaultStart <$true/$false>`
+3. Run `Set-SPOHomeSite -HomeSiteUrl <homesiteURL> -VivaConnectionsDefaultStart <$true/$false> -DraftMode <$true/$false>`
 
-   - The parameter should be set to **$false** to use the new Connections desktop experience as the default landing experience.
-   - The parameter should be set to **$true** to use a SharePoint home site as the default landing experience.
+   - The VivaConnectionsDefault parameter should be set to **$false** to use the new Connections desktop experience as the default landing experience.
+   - The VivaConnectionsDefault parameter should be set to **$true** to use a SharePoint home site as the default landing experience.
+   - The DraftMode parameter is set to **$true** by default, which will disable the global navigation and home site. The Connections desktop experience can be enabled in the Microsoft 365 Admin Center.
+   - Set the DraftMode parameter to **$false** to immediately enable the Connections desktop experience without going through the Admin Center.
 
    **Example:**
 


### PR DESCRIPTION
When running the Viva Connections default experience SPO Management Shell command as documented, the experience is in draft mode by default, thus removing the existing home site and global nav for users. I've added the DraftMode parameter and an explanation to clarify.