### PR TITLE
Update set-up-sftp.md

### DIFF
--- a/Viva/glint/setup/set-up-sftp.md
+++ b/Viva/glint/setup/set-up-sftp.md
@@ -68,7 +68,4 @@ The public PGP key provided by Viva Glint that your organization can optionally 
 
 To create a new public PGP key:
 
-1. Go to **Configuration** and select **General settings** in the **Service configuration** section.
-2. Select **Technical configuration** in the menu and then in **SFTP setup** choose **Manage**.
-3. To generate a new key, go to **PGP Encryption** and switch the toggle from **On** to **Off**, and then back to **On**.
-4. Select the copy icon next to the **Public Key** field or select the **Download .asc file** option to get the newly generated key.
+1. You'll need to open a support ticket by following these instructions https://learn.microsoft.com/en-us/viva/learning/help-support

--- a/Viva/glint/setup/set-up-sftp.md
+++ b/Viva/glint/setup/set-up-sftp.md
@@ -68,4 +68,4 @@ The public PGP key provided by Viva Glint that your organization can optionally 
 
 To create a new public PGP key:
 
-1. You'll need to open a support ticket by following these instructions https://learn.microsoft.com/en-us/viva/learning/help-support
+1. You'll need to open a support ticket by following these instructions https://learn.microsoft.com/viva/learning/help-support


### PR DESCRIPTION
Changed the instructions for creating a new PGP key since the existing instructions are incorrect.  The customer will need to open a support ticket so a SRE can generate the new keypair.