### PR TITLE
Update eac-storyline.md for IB attachment issues

### DIFF
--- a/Viva/engage/eac-storyline.md
+++ b/Viva/engage/eac-storyline.md
@@ -127,6 +127,9 @@ Files attached to storyline posts are stored in a hidden library in the authorâ€
 
    `https://<tenantname>-my.sharepoint.com/personal/<useridentifier>/VivaEngage/Attachments/Storyline`
 
+> [!NOTE]
+> Storyline file attachments are not supported for users with information barriers policies applied to their OneDrive.
+
 To determine the precise URL for a user's storyline page, follow these steps:
 
 1. Open the user's OneDrive in a browser.


### PR DESCRIPTION
Added a note/colorblock callout to reflect lack of support for file attachments in Storyline posts for users subject to IB policies on their OneDrives. This update is needed to reduce customer dsat when Storylines are enabled but users cannot include attachments with their posts.